### PR TITLE
하위 디렉토리에 설치시에 메뉴 추가시 type 들의 썸네일 안나오는 문제 해결

### DIFF
--- a/resources/views/uiobjects/menu/typeSelect.blade.php
+++ b/resources/views/uiobjects/menu/typeSelect.blade.php
@@ -5,11 +5,11 @@
    <div class="menutype_con">
 
     @if(sizeof($menuType['screenshot']) === 0)
-     <div class="thumbnail-box" style="background: url('/assets/core/common/img/no_image_632x654.jpg') ; height:228px; background-size: cover; " title="{{xe_trans('xe::noScreenshot')}}">
+     <div class="thumbnail-box" style="background: url({{asset('/assets/core/common/img/no_image_632x654.jpg')}}) ; height:228px; background-size: cover; " title="{{xe_trans('xe::noScreenshot')}}">
      </div>
     @else
      <div class="thumbnail-box"
-          style="height:228px; background: url('{{ (sizeof($menuType['screenshot'])>0)?$menuType['screenshot'][0]:'' }}') no-repeat top center; background-size: cover; ">
+          style="height:228px; background: url('{{ (sizeof($menuType['screenshot'])>0)?asset($menuType['screenshot'][0]):'' }}') no-repeat top center; background-size: cover; ">
      </div>
     @endif
 


### PR DESCRIPTION
image url 에 asset 함수로 감쌈

## 문제의 원인
* 하위 디렉토리에 XE3 설치시 메뉴 추가 화면에서 type들의 썸네일이 나오지 않는 문제*

## 패치 내역
*썸네일 (screenshot) URL을 출력할 때 asset 함수로 감쌈*
