### PR TITLE
Feature/translate

### DIFF
--- a/resources/lang/common.php
+++ b/resources/lang/common.php
@@ -2286,6 +2286,10 @@ return [
         'ko' => '기본정보',
         'en' => 'Default information',
     ],
+    'enterDefaultInfo' => [
+        'ko' => '기본 정보 입력',
+        'en' => 'Enter required information',
+    ],
     'descDefaultInfo' => [
         'ko' => '기본정보(이메일, 이름, 비밀번호) 입력 폼입니다.',
         'en' => 'This is a form to enter email, name and password.',

--- a/resources/views/user/skins/default/auth/register/forms/default.blade.php
+++ b/resources/views/user/skins/default/auth/register/forms/default.blade.php
@@ -1,4 +1,4 @@
-<h4>기본 정보 입력</h4>
+<h4>{{xe_trans('xe::enterDefaultInfo')}}</h4>
 <div class="auth-group">
     <label for="email" class="xe-sr-only">{{xe_trans('xe::email')}}</label>
     <input type="text" id="email" class="xe-form-control" placeholder="{{xe_trans('xe::email')}}" name="email" value="{{ old('email') }}" data-valid-name="{{xe_trans('xe::email')}}">


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
소셜로그인 플러그인이 적용되지 않은 상태에서 회원가입 페이지에 접속합니다.

## 문제의 원인
회원가입시 볼 수 있는 *기본 정보입력* 글자는 한국어 외 다른 언어로 웹사이트 운영시 그대로 출력됩니다.

## 패치 내역
- `resources/lang/common.php` 파일에 `기본 정보입력` 라벨을 다국어로 표기 될 수 있도록 `enterDefaultInfo` 추가
- `plugins/theme/components/skin/user/auth/views/register/forms/default.blade.php` 파일에 있는 `기본 정보입력` 라벨이 다국어로 표기 될 수 있도록 `{{xe_trans('xe::enterDefaultInfo')}}` 로 변경.

좋은하루되세요~