### PR TITLE
'XeStorage::upload() 가 Storage::put() 의 매개변수 $option 을 변경할 수 있도록 수정

### DIFF
--- a/core/src/Xpressengine/Media/Handlers/ImageHandler.php
+++ b/core/src/Xpressengine/Media/Handlers/ImageHandler.php
@@ -81,6 +81,7 @@ class ImageHandler extends AbstractHandler
      * @param null|string      $disk     storage disk
      * @param null|string      $path     saved path
      * @param null|string      $originId origin file id
+     * @param mixed            $option   disk option (ex. aws s3 'visibility: public')
      * @return Image
      */
     public function createThumbnails(
@@ -89,7 +90,8 @@ class ImageHandler extends AbstractHandler
         $code = null,
         $disk = null,
         $path = null,
-        $originId = null
+        $originId = null,
+        $option = []
     ) {
         $thumbnailer = $this->makeThumbnailer();
         $content = $thumbnailer->setOrigin($origin)->addCommand($command)->generate();
@@ -112,7 +114,9 @@ class ImageHandler extends AbstractHandler
             $path ?: '',
             $name,
             $disk,
-            $originId
+            $originId,
+            null,
+            $option
         );
 
         $image = $this->makeModel($file);

--- a/core/src/Xpressengine/Media/MediaManager.php
+++ b/core/src/Xpressengine/Media/MediaManager.php
@@ -211,11 +211,16 @@ class MediaManager
      * @param Media       $media      media instance
      * @param string|null $type       섬네일 생성 방식
      * @param array|null  $dimensions 섬네일 크기
+     * @param null        $path
+     * @param string|null $disk
+     * @param mixed       $option     disk option (ex. aws s3 'visibility: public')
      * @return Collection|Image[]
      */
-    public function createThumbnails(Media $media, $type = null, array $dimensions = null)
+    public function createThumbnails(Media $media, $type = null, array $dimensions = null, $path = null, $disk = null, $option = [])
     {
         $type = strtolower($type ?: $this->config['type']);
+        $path = $path ?: $this->config['path'];
+        $disk = $disk ?: $this->config['disk'];
         $dimensions = $dimensions ?: $this->config['dimensions'];
         $handler = $this->getHandlerByMedia($media);
 
@@ -233,9 +238,10 @@ class MediaManager
                     $content,
                     $command,
                     $code,
-                    $this->config['disk'],
-                    $this->config['path'],
-                    $media->getOriginKey()
+                    $disk,
+                    $path,
+                    $media->getOriginKey(),
+                    $option
                 );
         }
 

--- a/core/src/Xpressengine/Storage/FilesystemHandler.php
+++ b/core/src/Xpressengine/Storage/FilesystemHandler.php
@@ -72,11 +72,12 @@ class FilesystemHandler
      * @param string $content  file content
      * @param string $pathname be saved path and file name
      * @param string $disk     be saved disk name
+     * @param mixed  $option   disk option (ex. aws s3 'visibility: public')
      * @return bool
      */
-    public function store($content, $pathname, $disk)
+    public function store($content, $pathname, $disk, $option = [])
     {
-        return $this->getDisk($disk)->put($pathname, $content);
+        return $this->getDisk($disk)->put($pathname, $content, $option);
     }
 
     /**

--- a/core/src/Xpressengine/Storage/Storage.php
+++ b/core/src/Xpressengine/Storage/Storage.php
@@ -121,6 +121,7 @@ class Storage
      * @param string|null   $name     be saved file name
      * @param string|null   $disk     disk name (ex. local, ftp, s3 ...)
      * @param UserInterface $user     user instance
+     * @param mixed         $option   disk option (ex. aws s3 'visibility: public')
      * @return File
      */
     public function upload(
@@ -128,7 +129,8 @@ class Storage
         $path,
         $name = null,
         $disk = null,
-        UserInterface $user = null
+        UserInterface $user = null,
+        $option = []
     ) {
 
         $this->validateUploadedFile($uploaded);
@@ -147,7 +149,7 @@ class Storage
         $disk = $disk ?: $this->distributor->allot($uploaded);
         $user = $user ?: $this->auth->user();
 
-        if (!$this->files->store(file_get_contents($uploaded->getPathname()), $path . '/' . $name, $disk)) {
+        if (!$this->files->store(file_get_contents($uploaded->getPathname()), $path . '/' . $name, $disk, $option)) {
             throw new WritingFailException;
         }
 
@@ -196,9 +198,10 @@ class Storage
      * @param string|null   $disk     disk for saved
      * @param string|null   $originId original file id
      * @param UserInterface $user     user instance
+     * @param mixed         $option   disk option (ex. aws s3 'visibility: public')
      * @return File
      */
-    public function create($content, $path, $name, $disk = null, $originId = null, UserInterface $user = null)
+    public function create($content, $path, $name, $disk = null, $originId = null, UserInterface $user = null, $option = [])
     {
         $id = $this->keygen->generate();
         $path = $this->makePath($id, $path);
@@ -207,7 +210,7 @@ class Storage
         $disk = $disk ?: $this->distributor->allot($tempFile);
         $user = $user ?: $this->auth->user();
 
-        if (!$this->files->store($content, $path . '/' . $name, $disk)) {
+        if (!$this->files->store($content, $path . '/' . $name, $disk, $option)) {
             throw new WritingFailException;
         }
 


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
- `XeStorage::upload();`를 사용하여 이미지를 aws s3 에 업로드하면 private 상태로 업로드 됩니다.
- `XeMedia::createThumbnails();`를 사용하여 썸네일을 생성하여 업로드하면 private 상태로 업로드 됩니다. 

## 문제의 원인
`XeStorage::upload()` 또는` XeMedia::createThumbnails()` 에서 이미지를 생성하거나 만들면 `\Illuminate\Contracts\Filesystem\Filesystem` 의 메소드 중 하나인 `put` 메소드 의 매개 변수 중 $option 값이 기본값으로 지정되어서 문제입니다.

## 패치 내역
- `XeStorage::upload()` 와 `XeMedia::createThumbnails()` 에서 `\Illuminate\Contracts\Filesystem\Filesystem` 에 있는  `put` 메소드의 매개변수 $option 값을 설정할 수 있도록 하였습니다.
- `XeMedia::createThumbnails()` 에서 파일 드라이버 (local, s3 등)를 선택할 수 있도록 하였습니다.