### PR TITLE
프로필 수정 페이지의 $tabContent의 스킨이 항상 desktop으로 선택되는 문제 수정

### DIFF
--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -123,6 +123,8 @@ class UserController extends Controller
 
         $content = $selectedSection['content'];
         $selectedSection['selected'] = true;
+
+        $mode = $request->isMobile() ? 'mobile' : 'desktop';
         $tabContent = $content instanceof \Closure ? $content($user) : $content;
 
         return XePresenter::make('index', compact('user', 'menus', 'tabContent'));

--- a/app/Providers/UserServiceProvider.php
+++ b/app/Providers/UserServiceProvider.php
@@ -611,7 +611,7 @@ class UserServiceProvider extends ServiceProvider
     {
         UserHandler::setSettingsSections('settings', [
             'title' => 'xe::defaultSettings',
-            'content' => function ($user) {
+            'content' => function ($user, $mode = 'desktop') {
                 // dynamic field
                 $fieldTypes = $this->app['xe.dynamicField']->gets('user');
 
@@ -619,7 +619,7 @@ class UserServiceProvider extends ServiceProvider
                     ['assets/core/xe-ui-component/js/xe-form.js', 'assets/core/xe-ui-component/js/xe-page.js']
                 )->load();
 
-                $skin = $this->app['xe.skin']->getAssigned('user/settings');
+                $skin = $this->app['xe.skin']->getAssigned('user/settings', $mode);
 
                 return $skin->setView('edit')->setData(compact('user', 'fieldTypes'));
             }


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
*문제 재현 방법을 알려주세요.*
[회원 정보 수정 페이지 (user/settings)의 스킨이 데스크탑과 모바일 둘다 존재할때 tabContent의 내용이 항상 데스크탑의 스킨이 사용되는 문제.

## 문제의 원인
*어떤게 원인 이었나요?*
UserServiceProvider.php의 622라인의 클로저 안에서 getAssigned을 통해 스킨을 가져올때 SkinHandler.php의 mobileResolver가 null이어서 $resolver() === true ? 'mobile' : 'desktop'; 가 항상 desktop이 선택되는 문제

## 패치 내역
*어떤걸 수정했나요?*
getAssigned를 호출할때 $mode를 강제 지정하였습니다.

SkinHandler의 mobileResolver를 지정하여 수정하는 방법은 아직 코드를 정확히 분석하지 못해 찾지 못하여 이러한 방식으로 수정하였습니다. 구조상 $tabContent의 뷰를 불러올때 파라메터로 $mode를 넣는게 좋아보이지는 않아 더 나은 수정방식이 있으면 수정해 주세요. 감사합니다.