### PR TITLE
암호에 적합한 글자를 확인한다.

### DIFF
--- a/resources/views/install/index.blade.php
+++ b/resources/views/install/index.blade.php
@@ -311,7 +311,15 @@
                     return false;
                 }
             }
-
+            
+            var password_check = /[^!-\/:-@[-`{-~a-zA-Z0-9]/.test($(f['admin_password']).val())
+            if (password_check) {
+                $(f['admin_password']).css('backgroundColor', '#F49EA0');
+                alert('비밀번호로 사용가능한 문자는 영문과 특수문자만 가능합니다.');
+                $(f['admin_password']).focus();
+                return false;
+            }
+            
             if ($(f['admin_password']).val() !== $(f['admin_password_confirmation']).val()) {
                 alert('비밀번호가 일치하지 않습니다.');
                 $(f['admin_password_confirmation']).focus();


### PR DESCRIPTION
암호로 사용가능한 글자를 확인한다.
영문문자, 특수문자 만 입력 가능하도록 체크 한다.

Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
Issue #1090 에서 자세한 설명을 적어두었습니다.
암호의 문자로 한글이 들어가는 문제가 발생되어 암호로 사용가능한 문자를 체크 합니다.

## 문제의 원인
암호로 한글이 들어가기 때문에 설치시 혼선이 생기는 경우가 발생하였습니다.

## 패치 내역
암호로 영문자, 특수문자를 제외한 다른 문자가 들어간 것을 체크하도록 하였습니다.
