### PR TITLE
fix(media_library): 미디어 라이브러리 파일 업로드 UI 오류 수정

### DIFF
--- a/resources/assets/core/media_library/vue/app.vue
+++ b/resources/assets/core/media_library/vue/app.vue
@@ -102,7 +102,7 @@ export default {
       :class="{
         'media-library-layer-popup': true,
         'media-library-layer-popup--media-library': true,
-        'media-library-layer-popup--sidebar': $root.user.rating === 'super',
+        'media-library-layer-popup--sidebar': true,
         'media-library-layer-popup--upload': true
       }"
       tabindex="-1"


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
로그인한 계정 권한(super)에 따라 미디어 라이브러리의 UI가 깨집니다.

## 문제의 원인
미디어 라이브러리 vue 파일에서 `media-library-layer-popup--sidebar` CSS 클래스를 `$root.user.rating === 'super'` 조건에 따라 추가하고 있습니다.

## 패치 내역
fix #1100
