### PR TITLE
feat(commands): 데이터베이스 charset 변환 artisan 명령어 추가

### DIFF
--- a/app/Console/Commands/CharsetConvert.php
+++ b/app/Console/Commands/CharsetConvert.php
@@ -4,7 +4,6 @@ namespace App\Console\Commands;
 
 use App\Facades\XeDB;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Config;
 
 class CharsetConvert extends Command
 {

--- a/app/Console/Commands/CharsetConvert.php
+++ b/app/Console/Commands/CharsetConvert.php
@@ -46,10 +46,10 @@ class CharsetConvert extends Command
         $charset = $this->argument('charset');
         $collation = $this->argument('collation');
 
-        // XpressEngine과 연결돤 데이터베이스의 charset 변경
+        // XpressEngine과 연결된 데이터베이스의 문자셋 변경
         XeDB::unprepared("ALTER SCHEMA {$database} DEFAULT CHARACTER SET {$charset} DEFAULT COLLATE {$collation};");
 
-        // 데이터베이스에 속한 테이블의 charset 변경
+        // 데이터베이스에 속한 테이블의 문자셋 변경
         $tables = XeDB::select("SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = '{$database}'");
         $tables = array_map(function ($value) {
             return (array)$value;

--- a/app/Console/Commands/CharsetConvert.php
+++ b/app/Console/Commands/CharsetConvert.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Facades\XeDB;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+
+class CharsetConvert extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'xe:convert-charset
+                            {charset=utf8mb4 : Specify the charset for converting}
+                            {collation=utf8mb4_unicode_ci : Specify the collation for converting}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Convert database character set and collation';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $connection = config('database.default');
+        $database = config("database.connections.{$connection}.database");
+
+        $charset = $this->argument('charset');
+        $collation = $this->argument('collation');
+
+        // XpressEngine과 연결돤 데이터베이스의 charset 변경
+        XeDB::unprepared("ALTER SCHEMA {$database} DEFAULT CHARACTER SET {$charset} DEFAULT COLLATE {$collation};");
+
+        // 데이터베이스에 속한 테이블의 charset 변경
+        $tables = XeDB::select("SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = '{$database}'");
+        $tables = array_map(function ($value) {
+            return (array)$value;
+        }, $tables);
+
+        foreach ($tables as $table) {
+            XeDB::unprepared("ALTER TABLE {$table['TABLE_NAME']} CONVERT TO CHARACTER SET {$charset} COLLATE {$collation};");
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -66,7 +66,8 @@ class Kernel extends ConsoleKernel
         Commands\ThemeMake::class,
         Commands\SkinMake::class,
         Commands\DynamicFieldMake::class,
-        Commands\DynamicFieldSkinMake::class
+        Commands\DynamicFieldSkinMake::class,
+        Commands\CharsetConvert::class
     ];
 
     /**


### PR DESCRIPTION
이모지 지원 등의 문제로 데이터베이스의 charset을 `utf8mb4`로 지정할 필요가 있을 경우, 사용자의 선택에 따라 데이터베이스 문자셋을 변경할 수 있도록 하는 커밋입니다. resolve #1102 

## 패치 내역
https://github.com/xpressengine/xpressengine/blob/3c95b0d2ada9157174af56ff374adc067809cfbc/app/Console/Commands/XeInstall.php#L503-L504
XpressEngine을 설치하기 전이라면 위 두 줄을 `utf8mb4`로 바꾸고 설치를 진행하는 것으로 설정을 완료할 수 있지만, 이미 서비스 중인 사이트에서도 데이터베이스와 테이블의 문자셋을 변경할 수 있는 artisan 명령어를 추가했습니다.

## 참고
데이터베이스와 테이블의 charset을 변경하고 나서 `config/production/database.php` 설정도 바꿔주어야 하는데, 혹시 라라벨 내에서 자동으로 변경할 수 있는 방법이 있을까 찾아보다가 우선 config 파일은 수동으로 수정하는 방향으로 가정하고 진행했습니다.