### PR TITLE
feat(xeinstall): 설치할 때 charset 선택 과정 추가

### DIFF
--- a/app/Console/Commands/XeInstall.php
+++ b/app/Console/Commands/XeInstall.php
@@ -105,6 +105,7 @@ class XeInstall extends Command
             'host' => 'localhost',
             'dbname' => null,
             'port' => '3306',
+            'charset' => 'utf8',
             'username' => 'root',
             'password' => null,
             'prefix' => 'xe'
@@ -426,6 +427,9 @@ class XeInstall extends Command
         // dbname
         $dbInfo['dbname'] = $this->ask("Database name", $dbInfo['dbname']);
 
+        // charset
+        $dbInfo['charset'] = $this->choice("Character set", ['utf8', 'utf8mb4'], $dbInfo['charset']);
+
         // username
         $dbInfo['username'] = $this->ask("UserID", $dbInfo['username']);
 
@@ -500,8 +504,8 @@ class XeInstall extends Command
                     'username'  => $dbInfo['username'],
                     'password'  => $dbInfo['password'],
                     'port'      => $dbInfo['port'],
-                    'charset'   => 'utf8',
-                    'collation' => 'utf8_unicode_ci',
+                    'charset'   => $dbInfo['charset'],
+                    'collation' => $dbInfo['charset'].'_unicode_ci',
                     'prefix' => $prefix . '_',
                     'strict'    => false,
                 ],


### PR DESCRIPTION
<https://github.com/xpressengine/xpressengine/pull/1120#issuecomment-608196687> @akasima 님의 아이디어를 참고해서 기능을 추가했습니다.

![image](https://user-images.githubusercontent.com/24864600/79068759-3625a780-7d04-11ea-8d82-5d9b205690bd.png)
 
`php artisan xe:install` 명령어로 설치하는 과정에서 `utf8`과 `utf8mb4` 중 선택하는 절차를 추가했습니다. <https://github.com/xpressengine/xpressengine/issues/977#issuecomment-495459155> 문제를 고려해서 기본값은 `utf8`으로 뒀습니다.