### PR TITLE
윈도우 환경에서 artisan xe:update 실행시 버전인식 못하는 문제 해결

### DIFF
--- a/core/src/Xpressengine/Foundation/ReleaseProvider.php
+++ b/core/src/Xpressengine/Foundation/ReleaseProvider.php
@@ -84,7 +84,7 @@ class ReleaseProvider
                 throw new \Exception('fail to get released information');
             }
 
-            $lines = explode(PHP_EOL, $response->getBody()->getContents());
+            $lines = array_map("rtrim", explode("\n", $response->getBody()->getContents()));
             $this->coreVersions = Collection::make($lines)->filter()->map(function ($v) {
                 return basename(trim($v), '.zip');
             })->sort('version_compare')->values()->all();


### PR DESCRIPTION
## 문제 재현 방법

1. 윈도우에서 CMD로 php artisan xe:update 실행
2. 업데이트 안됨 (버전 인식 불가)

## 문제의 원인
*어떤게 원인 이었나요?*

윈도우에서 PHP_EOL로 explode 하는 함수가 작동하지 않았고, PHP_EOL과 버전정보문서(versions.txt)간의 new line 문자가 다른 것으로 추정

## 패치 내역
*어떤걸 수정했나요?*

윈도우 리눅스 양쪽에서 호환되도록 PHP_EOL 을 \n으로 변경하는 대신 array_map("rtrim"으로 윈도우 new line 문자들을 제거

(Stackoverflow 참고함 https://stackoverflow.com/questions/4975411/when-do-i-use-php-eol-instead-of-n-and-vice-versa-ajax-jquery-client-problem)