### PR TITLE
XE설치시 COMPOSER_HOME 값을 storage/framework/.composer 로 기본설정

### DIFF
--- a/migrations/PluginMigration.php
+++ b/migrations/PluginMigration.php
@@ -37,6 +37,6 @@ class PluginMigration extends Migration
      */
     public function installed()
     {
-        \DB::table('config')->insert(['name' => 'plugin', 'vars' => '[]']);
+        \DB::table('config')->insert(['name' => 'plugin', 'vars' => '{"composer_home":"storage\/framework\/.composer"}']);
     }
 }


### PR DESCRIPTION
이슈  #1124 해결용

## 문제 재현 방법
1. XE를 설치합니다.
2. `php artisan make:plugin name vendor`를 실행합니다.
3. COMPOSER_HOME 에러발생

## 문제의 원인
COMPOSER_HOME 기본값이 없습니다.

## 패치 내역
COMPOSER_HOME 기본값을 넣어주었습니다.
