### PR TITLE
(디버깅모드일때) Object of class DateTime could not be converted to string 에러 해결

### DIFF
--- a/app/Providers/DatabaseServiceProvider.php
+++ b/app/Providers/DatabaseServiceProvider.php
@@ -14,6 +14,7 @@
 
 namespace App\Providers;
 
+use Carbon\Carbon;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\ServiceProvider;
 use Monolog\Handler\StreamHandler;
@@ -53,7 +54,11 @@ class DatabaseServiceProvider extends ServiceProvider
                 $monoLog->pushHandler(new StreamHandler($logFile, Logger::INFO));
                 $prep = $query;
                 foreach ($bindings as $binding) {
-                    if($binding instanceof \DateTime) $binding = $binding->format(DATE_ATOM);
+                    if ($binding instanceof \DateTimeInterface) {
+                        $binding = new Carbon(
+                            $binding->format('Y-m-d H:i:s.u'), $binding->getTimezone()
+                        );
+                    }
                     $prep = preg_replace('#\?#', is_numeric($binding) ? $binding : "'" . $binding . "'", $prep, 1);
                 }
                 $monoLog->info($prep);

--- a/app/Providers/DatabaseServiceProvider.php
+++ b/app/Providers/DatabaseServiceProvider.php
@@ -53,6 +53,7 @@ class DatabaseServiceProvider extends ServiceProvider
                 $monoLog->pushHandler(new StreamHandler($logFile, Logger::INFO));
                 $prep = $query;
                 foreach ($bindings as $binding) {
+                    if($binding instanceof \DateTime) $binding = $binding->format(DATE_ATOM);
                     $prep = preg_replace('#\?#', is_numeric($binding) ? $binding : "'" . $binding . "'", $prep, 1);
                 }
                 $monoLog->info($prep);


### PR DESCRIPTION
## 문제 재현 방법
1. app.debug = true로 설정
2. 모델에 $dates Mutator 추가
3. 모델 저장
4. 에러

## 문제의 원인
#1158 

## 패치 내역
DatabaseServiceProvider에서 $binding을 string으로 변환할때 DateTime인 경우도 처리할 수 있게 if문 추가
