### PR TITLE
윈도우에서 private:update 명령 실행시 isPrivate()이 항상 false 리턴하는 버그수정

### DIFF
--- a/core/src/Xpressengine/Plugin/PluginEntity.php
+++ b/core/src/Xpressengine/Plugin/PluginEntity.php
@@ -793,7 +793,14 @@ class PluginEntity implements Arrayable, Jsonable
      */
     public function isPrivate()
     {
-        return is_link(dirname($this->pluginFile));
+        // is_link는 윈도우에 적용된 심볼릭링크 방식인 JUNCTION을 인식하지 못하기 때문에 별도로 구현
+        // 윈도우에선 윈도우용 디렉토리 문자열과 슬래시가 혼용되어 나오기 때문에, 슬래시를 OS에 맞는 Separator로 치환
+        $pluginPath = str_replace('/', DIRECTORY_SEPARATOR, dirname($this->pluginFile));
+        $realPath = realpath($pluginPath);
+        if ($realPath && $realPath !== $pluginPath) {
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
1. 윈도우 환경에서 `php artisan private:update XXXX` 실행
2. `The plugin[XXXX] is not private plugin` 에러 발생

## 문제의 원인
`isPrivate()`은 PHP내장함수 `is_link()`를 기반하여 만들어져 있는데, 윈도우에서 private 플러그인설치시 심볼릭 링크가 아닌 `JUNCTION` 으로 폴더가 만들어집니다.
이 경우 항상 `is_link()`가 `false`를 리턴하기 때문에 에러가 발생합니다.
https://github.com/xpressengine/xpressengine/blob/703293b425ff739e10b900977a17073416e5c258/core/src/Xpressengine/Plugin/PluginEntity.php#L789-L797

## 패치 내역
*어떤걸 수정했나요?*
https://github.com/contao-community-alliance/composer-plugin/issues/34#issuecomment-65497704
타 프로젝트 이슈를 참고하여 `is_link()` 기능을 직접 구현하였습니다.
