### PR TITLE
플러그인에 vendor가 없는 dependency(ext-json)를 추가하면 update 안되는 버그 해결

### DIFF
--- a/core/src/Xpressengine/Plugin/PluginHandler.php
+++ b/core/src/Xpressengine/Plugin/PluginHandler.php
@@ -336,7 +336,11 @@ class PluginHandler
         $collection = $this->getPlugins();
         $dependencyPlugins = [];
         foreach ($dependencies as $dependency => $version) {
-            $id = array_last(explode('/', $dependency));
+            // Platform 의존성은 검사를 건너뜀
+            if (0 === stripos($dependency, 'ext-')) {
+                continue;
+            }
+            list($vendor, $id) = explode('/', $dependency);
             $entity = $collection->get($id);
             if ($entity !== null && $entity->getName() === $dependency) {
                 $dependencyPlugins[$id] = $entity;

--- a/core/src/Xpressengine/Plugin/PluginHandler.php
+++ b/core/src/Xpressengine/Plugin/PluginHandler.php
@@ -336,7 +336,7 @@ class PluginHandler
         $collection = $this->getPlugins();
         $dependencyPlugins = [];
         foreach ($dependencies as $dependency => $version) {
-            list($venacdor, $id) = explode('/', $dependency);
+            $id = array_last(explode('/', $dependency));
             $entity = $collection->get($id);
             if ($entity !== null && $entity->getName() === $dependency) {
                 $dependencyPlugins[$id] = $entity;

--- a/core/src/Xpressengine/Plugin/PluginHandler.php
+++ b/core/src/Xpressengine/Plugin/PluginHandler.php
@@ -337,7 +337,7 @@ class PluginHandler
         $dependencyPlugins = [];
         foreach ($dependencies as $dependency => $version) {
             // Platform 의존성은 검사를 건너뜀
-            if (0 === stripos($dependency, 'ext-')) {
+            if (in_array($dependency, ['php', 'php-64bit', 'hhvm']) || 0 === stripos($dependency, 'ext-') || 0 === stripos($dependency, 'lib-')) {
                 continue;
             }
             list($vendor, $id) = explode('/', $dependency);


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
1. XXXX 플러그인 composer.json의 require 필드에 `ext-json: *` 추가
2. `php artisan private:update XXXX` 실행
3. 에러 발생
```
The system cannot find the file specified.

In PluginHandler.php line 339:
                       
  Undefined offset: 1  
                       
```

## 문제의 원인
*어떤게 원인 이었나요?*
`getDependencies()`에서 explode시 `ext-json`은 vendor가 없기 때문에 index 1이 존재하지 않아 발생하는 에러입니다.
https://github.com/xpressengine/xpressengine/blob/703293b425ff739e10b900977a17073416e5c258/core/src/Xpressengine/Plugin/PluginHandler.php#L339

## 패치 내역
*어떤걸 수정했나요?*
어차피 vendor이름은 사용하지 않고 있어서 아래 코드로 대체하였습니다. 
```php
$id = array_last(explode('/', $dependency));
```