### PR TITLE
윈도우에서 private:update 명령 실행시 발생하는 에러 해결 (Junction 호환성 추가)

### DIFF
--- a/app/Console/Commands/PrivateUpdateCommand.php
+++ b/app/Console/Commands/PrivateUpdateCommand.php
@@ -14,6 +14,8 @@
 
 namespace App\Console\Commands;
 
+use Composer\Util\Filesystem;
+
 /**
  * Class PrivateUpdateCommand
  *
@@ -63,7 +65,8 @@ class PrivateUpdateCommand extends PluginCommand
 
             $this->info('Unlink plugin');
             $this->output->write('  - Unlinking ... ');
-            if (!app('files')->delete($plugin->getPath())) {
+            // 윈도우와의 호환성을 위해 Composer FileSystem 유틸로 삭제 (Junction 삭제 지원)
+            if (!app(Filesystem::class)->remove($plugin->getPath())) {
                 throw new \RuntimeException('Unable to unlink.');
             }
             $this->info('done');

--- a/core/src/Xpressengine/Plugin/PluginEntity.php
+++ b/core/src/Xpressengine/Plugin/PluginEntity.php
@@ -14,6 +14,7 @@
 
 namespace Xpressengine\Plugin;
 
+use Composer\Util\Filesystem;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Str;
@@ -793,7 +794,8 @@ class PluginEntity implements Arrayable, Jsonable
      */
     public function isPrivate()
     {
-        return is_link(dirname($this->pluginFile));
+        $pluginDir = dirname($this->pluginFile);
+        return is_link($pluginDir) || app(Filesystem::class)->isJunction($pluginDir);
     }
 
     /**


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
1. 윈도우 환경에서 `php artisan private:update XXXX` 실행
2. `The plugin[XXXX] is not private plugin` 에러 발생
3. 2번을 해결해도
```
Unlink plugin
  - Unlinking ... Cannot create a file when that file already exists.

In PrivateUpdateCommand.php line 68:
                     
  Unable to unlink.  
                    
```
에러 발생

## 문제의 원인
`isPrivate()`은 PHP내장함수 `is_link()`를 기반하여 만들어져 있는데, 윈도우에서 private 플러그인설치시 심볼릭 링크가 아닌 `JUNCTION` 으로 폴더가 만들어집니다.
이 경우 항상 `is_link()`가 `false`를 리턴하기 때문에 에러가 발생합니다.
Unlink 프로세스에서도 Junction에 대한 삭제를 지원하지 않기 때문에 에러가 발생합니다.
https://github.com/xpressengine/xpressengine/blob/703293b425ff739e10b900977a17073416e5c258/core/src/Xpressengine/Plugin/PluginEntity.php#L789-L797

## 패치 내역
*어떤걸 수정했나요?*
Composer FileSystem 유틸에 있는 함수들을 이용하여 Junction도 인식 & 삭제 가능하도록 변경하였습니다.
