### PR TITLE
plugin:activate 명령어 추가

### DIFF
--- a/app/Console/Commands/PluginActivate.php
+++ b/app/Console/Commands/PluginActivate.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * PluginActivate.php
+ *
+ * PHP version 7
+ *
+ * @category    Commands
+ * @package     App\Console\Commands
+ * @author      XE Team (developers) <developers@xpressengine.com>
+ * @copyright   2020 Copyright XEHub Corp. <https://www.xehub.io>
+ * @license     http://www.gnu.org/licenses/lgpl-3.0-standalone.html LGPL
+ * @link        http://www.xpressengine.com
+ */
+namespace App\Console\Commands;
+
+/**
+ * Class PluginActivate
+ *
+ * @category    Commands
+ * @package     App\Console\Commands
+ * @author      XE Team (developers) <developers@xpressengine.com>
+ * @copyright   2020 Copyright XEHub Corp. <https://www.xehub.io>
+ * @license     http://www.gnu.org/licenses/lgpl-3.0-standalone.html LGPL
+ * @link        http://www.xpressengine.com
+ */
+class PluginActivate extends PluginCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'plugin:activate
+                        {plugin* : The plugin to activate.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Activate a plugin of XpressEngine';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function handle()
+    {
+        $plugins = $this->getPluginList($this->argument('plugin'));
+
+        foreach ($plugins as $id => $plugin) {
+            if ($plugin === null) {
+                // 설치되어 있지 않은 플러그인입니다.
+                throw new \Exception('Plugin not found : '.$id);
+            }
+            if (!$plugin->isActivated()) {
+                $this->line("Activating $id");
+                $this->handler->activatePlugin($plugin->getId());
+                $this->output->success("$id is activated");
+            }
+        }
+    }
+
+    /**
+     * Get plugins data.
+     *
+     * @param array $pluginIds plugin ids
+     * @return array
+     * @throws \Exception
+     */
+    protected function getPluginList($pluginIds)
+    {
+        $collection = $this->handler->getAllPlugins(true);
+        return $collection->getList($pluginIds);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -60,6 +60,7 @@ class Kernel extends ConsoleKernel
         Commands\PluginInstall::class,
         Commands\PluginUpdate::class,
         Commands\PluginUninstall::class,
+        Commands\PluginActivate::class,
         Commands\PluginComposerSync::class,
         Commands\PrivateUpdateCommand::class,
         Commands\PluginPrivateInstall::class,


### PR DESCRIPTION
https://www.xpressengine.com/forum/php-artisan-%EB%AA%85%EB%A0%B9%EC%96%B4%EB%A1%9C-%ED%94%8C%EB%9F%AC%EA%B7%B8%EC%9D%B8-activation-%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95%EC%9D%B4-%EC%9E%88%EB%82%98%EC%9A%94
포럼에 질문으로 올렸었는데, 컨트롤러에 있는 activate 기능 참고하여 간단하게 구현해봤습니다.

플러그인 활성화때 private 플러그인은 가끔 composer update를 같이해서 timeout 에러가 빈번합니다.

cli 환경에서는 timeout 에러가 없기 때문에, 이런 작업은 주로 artisan 명령어로 하는데 activation 명령어는 없는것 같아 만들어봤습니다.