### PR TITLE
nginx에서 plugins폴더 아래 파일을 가져올수 없는 버그 해결 (index.php로 rewrite됨)

### DIFF
--- a/example.xe3-nginx-rewrite.conf
+++ b/example.xe3-nginx-rewrite.conf
@@ -16,14 +16,11 @@ location / {
     location ~ ^/[a-zA-Z0-9\-\_]+\.html? {
         try_files $uri /index.php?$args;
     }
-    location ^~ /(assets|plugins|storage/app/public)/ {
+    location ~ ^/(assets|plugins|storage/app/public)/ {
         try_files $uri /index.php?$args;
     }
     location ~ ^/favicon* {
         try_files $uri /index.php?$args;
-    }
-    location ^~ /.well-known/ {
-        try_files $uri =404;
     }
 
     rewrite ^.* /index.php;


### PR DESCRIPTION
## 문제 재현 방법
1. nginx설정을 서버에 넣고 실행
2. 메인화면에 Together테마 아이콘이 보이지 않음 (폰트파일을 읽어오는 대신 Laravel로 라우팅됨)
![image](https://user-images.githubusercontent.com/8064923/85868020-b38d8e00-b804-11ea-8b2c-fed5e32ef7d0.png)
![image](https://user-images.githubusercontent.com/8064923/85868109-cf912f80-b804-11ea-9cca-766df8506ab9.png)
![image](https://user-images.githubusercontent.com/8064923/85868195-ecc5fe00-b804-11ea-85f4-54082add5238.png)


## 문제의 원인
1. 샘플로 제공된 nginx 설정이 문제였음... (시간 많이 썼습니다...ㅠ)
https://github.com/xpressengine/xpressengine/blob/5d09e1a1eace9f3f4006c2e49765c72ff9d3c445/example.xe3-nginx-rewrite.conf#L19-L21
위 문법은 인식되지 않고, 아래처럼 해야 인식됨 (Stackoverflow참조)
https://stackoverflow.com/questions/35320674/how-can-i-have-same-rule-for-two-locations-in-nginx-config
```
    location ~ ^/(assets|plugins|storage/app/public)/ {
        try_files $uri /index.php?$args;
    }
```

변경된 룰의 검증이 필요하시다면, nginx 룰 테스트 사이트에서 검증해보실수 있습니다.
https://nginx.viraptor.info/

## 패치 내역
위에 적었습니다.

추가적으로, `.well-known` 룰도 중복되어 하나는 제거하였습니다. (검증완료)
