### PR TITLE
PluginNotFoundException에서 plugin이름이 :plugin으로 나오는 버그 수정

### DIFF
--- a/core/src/Xpressengine/Plugin/PluginHandler.php
+++ b/core/src/Xpressengine/Plugin/PluginHandler.php
@@ -238,7 +238,7 @@ class PluginHandler
 
         // 플러그인이 존재하는지 검사한다.
         if ($entity === null) {
-            throw new PluginNotFoundException(['pluginName' => $pluginId]);
+            throw new PluginNotFoundException(['plugin' => $pluginId]);
         }
 
         // 플러그인이 이미 활성화되어있는 상태인지 체크한다.


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
1. plugins 폴더의 플러그인을 지우고 xe:install
2. 에러 발생시 메세지에 플러그인 이름이 :plugin으로 나옴

## 문제의 원인
템플릿은 `:plugin`으로 되어있는데, 데이터는 `pluginName`으로 넘어가서 발생하는 문제

## 패치 내역
데이터를 `pluginName`에서 `plugin`으로 수정해주었습니다
