### PR TITLE
FormSelect에서 multiple 옵션 사용시 value가 인식되지 않는 버그 해결

### DIFF
--- a/app/UIObjects/Form/FormSelect.php
+++ b/app/UIObjects/Form/FormSelect.php
@@ -81,7 +81,7 @@ class FormSelect extends AbstractUIObject
                         if ($selectedValue === null) {
                             $selected = array_get($option, 'selected', false) ? 'selected="selected"' : '';
                         } else {
-                            $selected = $value === $selectedValue ? 'selected="selected"' : '';
+                            $selected = in_array($value, (array) $selectedValue) ? 'selected="selected"' : '';
                         }
                         $optionEl = "<option value=\"$value\" $selected>$text</option>";
                         $select->append($optionEl);


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
1. FormSelect 사용시 mutiple 옵션을 주고, value를 배열로 넘김
2. value를 인식하지 못해 select되지 않음

## 문제의 원인
value를 === 으로 비교하기 때문에 배열값은 인식 불가함

## 패치 내역
=== 비교 대신 value를 array로 캐스팅하여 in_array로 체크하도록 함
