### PR TITLE
FormSelect에 optgroups 구현

### DIFF
--- a/app/UIObjects/Form/FormSelect.php
+++ b/app/UIObjects/Form/FormSelect.php
@@ -63,27 +63,29 @@ class FormSelect extends AbstractUIObject
                 case 'label':
                     $label->removeClass('hidden')->html($arg);
                     break;
+                case 'optgroups':
+                    $groups = $arg;
+                    foreach ($groups as $group) {
+                        $groupAttrs = array_except($group, 'options');
+                        $optgroupEl = new Element('optgroup', $groupAttrs);
+
+                        $options = array_get($group, 'options');
+                        debug($options);
+                        foreach ($options as $value => $option) {
+                            $optionEl = $this->processOption($value, $option, $selectedValue);
+                            $optgroupEl->append($optionEl);
+                        }
+
+                        $select->append($optgroupEl);
+                    }
+                    break;
                 case 'options':
                     $options = $arg;
                     if (is_callable($options)) {
                         $options = $options();
                     }
                     foreach ($options as $value => $option) {
-                        if (is_array($option) === false) {
-                            $text = $option;
-                            if (is_string($value) === false) {
-                                $value = $option;
-                            }
-                        } else {
-                            $value = array_get($option, 'value', $value);
-                            $text = array_get($option, 'text', $value);
-                        }
-                        if ($selectedValue === null) {
-                            $selected = array_get($option, 'selected', false) ? 'selected="selected"' : '';
-                        } else {
-                            $selected = in_array($value, (array) $selectedValue) ? 'selected="selected"' : '';
-                        }
-                        $optionEl = "<option value=\"$value\" $selected>$text</option>";
+                        $optionEl = $this->processOption($value, $option, $selectedValue);
                         $select->append($optionEl);
                     }
                     break;
@@ -112,5 +114,24 @@ class FormSelect extends AbstractUIObject
         $this->template = $box->append([$label, $select, $description])->render();
 
         return parent::render();
+    }
+
+    protected function processOption($value, $option, $selectedValue)
+    {
+        if (is_array($option) === false) {
+            $text = $option;
+            if (is_string($value) === false) {
+                $value = $option;
+            }
+        } else {
+            $value = array_get($option, 'value', $value);
+            $text = array_get($option, 'text', $value);
+        }
+        if ($selectedValue === null) {
+            $selected = array_get($option, 'selected', false) ? 'selected="selected"' : '';
+        } else {
+            $selected = in_array($value, (array) $selectedValue) ? 'selected="selected"' : '';
+        }
+        return "<option value=\"$value\" $selected>$text</option>";
     }
 }

--- a/app/UIObjects/Form/FormSelect.php
+++ b/app/UIObjects/Form/FormSelect.php
@@ -70,7 +70,6 @@ class FormSelect extends AbstractUIObject
                         $optgroupEl = new Element('optgroup', $groupAttrs);
 
                         $options = array_get($group, 'options');
-                        debug($options);
                         foreach ($options as $value => $option) {
                             $optionEl = $this->processOption($value, $option, $selectedValue);
                             $optgroupEl->append($optionEl);


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
현재 FormSelect UIO에 optgroup을 사용할수 있는 방법이 없음

## 문제의 원인


## 패치 내역
FormSelect에 optgroups 라는 옵션을 받아올수 있도록 구현
