### PR TITLE
(Issue #1407) defer, async 메서드 추가

### DIFF
--- a/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
+++ b/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
@@ -41,26 +41,4 @@ trait AttributeTrait
         $this->attributes[$name] = $value;
         return $this;
     }
-
-    /**
-     * 태그에 defer 속성을 지정한다.
-     *
-     * @return $this
-     */
-    public function defer()
-    {
-        $this->attributes['defer'] = '';
-        return $this;
-    }
-
-    /**
-     * 태그에 async 속성을 지정한다.
-     *
-     * @return $this
-     */
-    public function async()
-    {
-        $this->attributes['async'] = '';
-        return $this;
-    }
 }

--- a/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
+++ b/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
@@ -41,4 +41,16 @@ trait AttributeTrait
         $this->attributes[$name] = $value;
         return $this;
     }
+
+    public function defer()
+    {
+        $this->attributes['defer'] = '';
+        return $this;
+    }
+
+    public function async()
+    {
+        $this->attributes['async'] = '';
+        return $this;
+    }
 }

--- a/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
+++ b/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
@@ -42,12 +42,22 @@ trait AttributeTrait
         return $this;
     }
 
+    /**
+     * 태그에 defer 속성을 지정한다.
+     *
+     * @return $this
+     */
     public function defer()
     {
         $this->attributes['defer'] = '';
         return $this;
     }
 
+    /**
+     * 태그에 async을 지정한다.
+     *
+     * @return $this
+     */
     public function async()
     {
         $this->attributes['async'] = '';

--- a/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
+++ b/core/src/Xpressengine/Presenter/Html/Tags/AttributeTrait.php
@@ -54,7 +54,7 @@ trait AttributeTrait
     }
 
     /**
-     * 태그에 async을 지정한다.
+     * 태그에 async 속성을 지정한다.
      *
      * @return $this
      */

--- a/core/src/Xpressengine/Presenter/Html/Tags/JSFile.php
+++ b/core/src/Xpressengine/Presenter/Html/Tags/JSFile.php
@@ -219,7 +219,10 @@ class JSFile
         $attr = '';
         if (count($this->attributes) > 0) {
             foreach ($this->attributes as $name => $value) {
-                $attr .= ' '.$name.'="'.$value.'"';
+                $attr .= ' '.$name;
+                if (empty($value) === false) {
+                    $attr .= '="'.$value.'"';
+                }
             }
         }
 

--- a/core/src/Xpressengine/Presenter/Html/Tags/JSFile.php
+++ b/core/src/Xpressengine/Presenter/Html/Tags/JSFile.php
@@ -164,6 +164,28 @@ class JSFile
     }
 
     /**
+     * 태그에 defer 속성을 지정한다.
+     *
+     * @return $this
+     */
+    public function defer()
+    {
+        $this->attr('defer', '');
+        return $this;
+    }
+
+    /**
+     * 태그에 async 속성을 지정한다.
+     *
+     * @return $this
+     */
+    public function async()
+    {
+        $this->attr('async','');
+        return $this;
+    }
+
+    /**
      * unload
      *
      * @return void


### PR DESCRIPTION
 `AttributeTrait` 의 `attr` 메서드를 사용해도 충분하지만 저 또한 해당 메서드들이 있으면 더 직관적일 것 같아  `defer`, `async` 메서드를 추가했습니다.

## 패치 내역
#### [Presenter/Html/Tags/JSFile.php](https://github.com/xpressengine/xpressengine/compare/develop...Laeng:develop?expand=1#diff-1e089b8710e73113f4f3d397f8250ae794618b9ad068fce164e60b381856af44)
- `attr`의 값이 있을 때만 속성 값을 넣도록 변경

#### [Presenter/Html/Tags/AttributeTrait.php](https://github.com/xpressengine/xpressengine/compare/develop...Laeng:develop?expand=1#diff-0867fab8f6d9991c8041e82a5286e456f2d2c4611f7afddb71344b908dc80dae)
- `defer()`, `async()` 메서드 추가