### PR TITLE
[laravel 6.x] Model - keyType

### DIFF
--- a/core/src/Xpressengine/Counter/Models/CounterLog.php
+++ b/core/src/Xpressengine/Counter/Models/CounterLog.php
@@ -15,6 +15,7 @@
 namespace Xpressengine\Counter\Models;
 
 use Xpressengine\Database\Eloquent\DynamicModel;
+use Xpressengine\User\Models\User;
 
 /**
  * CounterLog
@@ -24,7 +25,7 @@ use Xpressengine\Database\Eloquent\DynamicModel;
  * @property string counter_option
  * @property string target_id
  * @property string user_id
- * @property integer point
+ * @property int point
  * @property string ipaddress
  * @property string created_at
  *
@@ -54,31 +55,24 @@ class CounterLog extends DynamicModel
      */
     public function user()
     {
-        return $this->hasOne('Xpressengine\User\Models\User', 'id', 'user_id');
+        return $this->hasOne(User::class, 'id', 'user_id');
     }
 
-
-    public static function boot()
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        $currentSiteKeyResolver = static function ($model) {
+            if (isset($model->site_key) === false) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
-        });
+        };
 
-        self::updating(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
-        self::saving(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
+        static::creating($currentSiteKeyResolver);
+        static::updating($currentSiteKeyResolver);
+        static::saving($currentSiteKeyResolver);
     }
 }

--- a/core/src/Xpressengine/Document/Models/Document.php
+++ b/core/src/Xpressengine/Document/Models/Document.php
@@ -176,6 +176,11 @@ class Document extends DynamicModel
     ];
 
     /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * division 테이블로 변경
      *
      * @param string $instanceId instance id

--- a/core/src/Xpressengine/Document/Models/Revision.php
+++ b/core/src/Xpressengine/Document/Models/Revision.php
@@ -15,6 +15,7 @@
 namespace Xpressengine\Document\Models;
 
 use Xpressengine\Database\Eloquent\DynamicModel;
+use Xpressengine\User\Models\User;
 
 /**
  * Revision
@@ -29,15 +30,15 @@ use Xpressengine\Database\Eloquent\DynamicModel;
  * @property string writer
  * @property string email
  * @property string certify_key
- * @property integer read_count
- * @property integer comment_count
- * @property integer assent_count
- * @property integer dissent_count
- * @property integer approved
- * @property integer published
- * @property integer status
- * @property integer display
- * @property integer format
+ * @property int read_count
+ * @property int comment_count
+ * @property int assent_count
+ * @property int dissent_count
+ * @property int approved
+ * @property int published
+ * @property int status
+ * @property int display
+ * @property int format
  * @property string locale
  * @property string title
  * @property string content
@@ -65,7 +66,7 @@ class Revision extends DynamicModel
     /**
      * @var string
      */
-    public $table = 'documents_revision';
+    protected $table = 'documents_revision';
 
     /**
      * @var bool
@@ -76,10 +77,30 @@ class Revision extends DynamicModel
      * @var array
      */
     protected $fillable = [
-        'revision_no', 'id', 'parent_id', 'instance_id', 'user_id', 'writer', 'approved',
-        'published', 'status', 'display', 'locale', 'title',
-        'content', 'pure_content', 'created_at', 'published_at', 'head', 'reply',
-        'list_order', 'ipaddress', 'user_type', 'certify_key', 'email', 'site_key'
+        'revision_no',
+        'id',
+        'parent_id',
+        'instance_id',
+        'user_id',
+        'writer',
+        'approved',
+        'published',
+        'status',
+        'display',
+        'locale',
+        'title',
+        'content',
+        'pure_content',
+        'created_at',
+        'published_at',
+        'head',
+        'reply',
+        'list_order',
+        'ipaddress',
+        'user_type',
+        'certify_key',
+        'email',
+        'site_key'
     ];
 
     /**
@@ -93,37 +114,35 @@ class Revision extends DynamicModel
     protected $primaryKey = 'revision_id';
 
     /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * user relationship
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user()
     {
-        return $this->belongsTo('Xpressengine\User\Models\User', 'user_id');
+        return $this->belongsTo(User::class, 'user_id');
     }
 
-
-    public static function boot()
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        $currentSiteKeyResolver = static function ($model) {
+            if (isset($model->site_key) === false) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
-        });
+        };
 
-        self::updating(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
-        self::saving(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
+        static::creating($currentSiteKeyResolver);
+        static::updating($currentSiteKeyResolver);
+        static::saving($currentSiteKeyResolver);
     }
 }

--- a/core/src/Xpressengine/Log/Models/Log.php
+++ b/core/src/Xpressengine/Log/Models/Log.php
@@ -11,6 +11,7 @@
  * @license     http://www.gnu.org/licenses/lgpl-3.0-standalone.html LGPL
  * @link        http://www.xpressengine.com
  */
+
 namespace Xpressengine\Log\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,31 +31,70 @@ use Xpressengine\User\Models\User;
  */
 class Log extends DynamicModel
 {
+    /**
+     * @var \Closure
+     */
     protected static $detailResolver;
 
-    protected $table = 'admin_log';
-
+    /**
+     * @var bool
+     */
     public $incrementing = false;
 
+    /**
+     * @var string
+     */
+    protected $table = 'admin_log';
+
+    /**
+     * @var bool
+     */
     protected $dynamic = false;
 
+    /**
+     * @var bool
+     */
     public $timestamps = true;
 
+    /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * @var string[]
+     */
     protected $casts = [
         'parameters' => 'array',
         'data' => 'array'
     ];
 
+    /**
+     * @var array
+     */
     protected $appends = [];
 
+    /**
+     * @var string[]
+     */
     protected $fillable = [
-        'type', 'user_id', 'method', 'url', 'parameters', 'summary', 'data', 'target_id', 'ipaddress', 'created_at', 'site_key'
+        'type',
+        'user_id',
+        'method',
+        'url',
+        'parameters',
+        'summary',
+        'data',
+        'target_id',
+        'ipaddress',
+        'created_at',
+        'site_key'
     ];
 
     /**
      * set log detail info resolver
      *
-     * @param \Closure $resolver resolver
+     * @param  \Closure  $resolver  resolver
      *
      * @return void
      */
@@ -74,19 +114,13 @@ class Log extends DynamicModel
     }
 
     /**
-     * user를 확인해서 삭제된 user이면 UnknownUser를 반환
+     * user 확인해서 삭제된 user 인 경우엔 UnknownUser 반환
      *
      * @return User|UnknownUser
      */
     public function getUser()
     {
-        $user = $this->user;
-
-        if ($user == null) {
-            $user = new UnknownUser();
-        }
-
-        return $user;
+        return $this->user ?? new UnknownUser();
     }
 
     /**
@@ -100,28 +134,21 @@ class Log extends DynamicModel
         return $resolver($this);
     }
 
-
-    public static function boot()
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        $currentSiteKeyResolver = static function ($model) {
+            if (isset($model->site_key) === false) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
-        });
+        };
 
-        self::updating(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
-        self::saving(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
+        static::creating($currentSiteKeyResolver);
+        static::updating($currentSiteKeyResolver);
+        static::saving($currentSiteKeyResolver);
     }
 }

--- a/core/src/Xpressengine/MediaLibrary/Models/MediaLibraryFile.php
+++ b/core/src/Xpressengine/MediaLibrary/Models/MediaLibraryFile.php
@@ -30,13 +30,37 @@ use Xpressengine\User\Models\User;
  */
 class MediaLibraryFile extends DynamicModel
 {
-    protected $table = 'media_library_files';
-
+    /**
+     * @var bool
+     */
     public $incrementing = false;
 
+    /**
+     * @var string
+     */
+    protected $table = 'media_library_files';
+
+    /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * @var string[]
+     */
     protected $fillable = [
-        'file_id', 'origin_file_id', 'folder_id', 'user_id', 'title', 'ext', 'caption',
-        'alt_text', 'description', 'site_key'
+        'file_id',
+        'origin_file_id',
+        'folder_id',
+        'user_id',
+        'title',
+        'ext',
+        'caption',
+        'alt_text',
+        'description',
+        'site_key'
     ];
 
     /**
@@ -60,11 +84,7 @@ class MediaLibraryFile extends DynamicModel
      */
     public function getTitleAttribute()
     {
-        if ($this->attributes['title'] == '') {
-            return $this->file->clientname;
-        } else {
-            return $this->attributes['title'];
-        }
+        return $this->attributes['title'] ?: $this->file->clientname;
     }
 
     /**
@@ -75,27 +95,21 @@ class MediaLibraryFile extends DynamicModel
         return $this->hasOne(User::class, 'id', 'user_id');
     }
 
-    public static function boot()
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        $currentSiteKeyResolver = static function ($model) {
+            if (isset($model->site_key) === false) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
-        });
+        };
 
-        self::updating(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
-        self::saving(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
+        static::creating($currentSiteKeyResolver);
+        static::updating($currentSiteKeyResolver);
+        static::saving($currentSiteKeyResolver);
     }
 }

--- a/core/src/Xpressengine/Site/Site.php
+++ b/core/src/Xpressengine/Site/Site.php
@@ -31,9 +31,22 @@ use Xpressengine\Database\Eloquent\DynamicModel;
  * @property string $host           지정된 도메인
  * @property string $site_key       고유한 식별자
  */
-
 class Site extends DynamicModel
 {
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = true;
+
     /**
      * The table associated with the model.
      *
@@ -53,19 +66,15 @@ class Site extends DynamicModel
      *
      * @var array
      */
-    protected $fillable = ['site_key', 'host'];
+    protected $fillable = [
+        'site_key',
+        'host'
+    ];
 
     /**
-     * Indicates if the IDs are auto-incrementing.
+     * The "type" of the auto-incrementing ID.
      *
-     * @var bool
+     * @var string
      */
-    public $incrementing = false;
-
-    /**
-     * Indicates if the model should be timestamped.
-     *
-     * @var bool
-     */
-    public $timestamps = true;
+    protected $keyType = 'string';
 }

--- a/core/src/Xpressengine/Tag/Tag.php
+++ b/core/src/Xpressengine/Tag/Tag.php
@@ -14,9 +14,6 @@
 
 namespace Xpressengine\Tag;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Query\Expression;
 use Xpressengine\Database\Eloquent\DynamicModel;
 
 /**
@@ -68,9 +65,9 @@ class Tag extends DynamicModel
     {
         if (array_key_exists('cnt', $this->getAttributes())) {
             return $this->getAttribute('cnt');
-        } else {
-            return $this->getAttribute('count');
         }
+
+        return $this->getAttribute('count');
     }
 
     /**

--- a/core/src/Xpressengine/User/Models/Term.php
+++ b/core/src/Xpressengine/User/Models/Term.php
@@ -29,27 +29,6 @@ use Xpressengine\Database\Eloquent\DynamicModel;
 class Term extends DynamicModel
 {
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'user_terms';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = ['key', 'locale', 'title', 'content', 'description', 'order', 'is_enabled', 'is_require', 'site_key'];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = ['is_enabled' => 'bool', 'is_require' => 'bool'];
-
-    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool
@@ -64,6 +43,47 @@ class Term extends DynamicModel
     public $timestamps = false;
 
     /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'user_terms';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'key',
+        'locale',
+        'title',
+        'content',
+        'description',
+        'order',
+        'is_enabled',
+        'is_require',
+        'site_key'
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'is_enabled' => 'bool',
+        'is_require' => 'bool'
+    ];
+
+    /**
+     * The "type" of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * get is term require
      *
      * @return bool
@@ -73,27 +93,21 @@ class Term extends DynamicModel
         return $this->getAttribute('is_require') === true;
     }
 
-    public static function boot()
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        $currentSiteKeyResolver = static function ($model) {
+            if (isset($model->site_key) === false) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
-        });
+        };
 
-        self::updating(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
-        self::saving(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
+        static::creating($currentSiteKeyResolver);
+        static::updating($currentSiteKeyResolver);
+        static::saving($currentSiteKeyResolver);
     }
 }

--- a/core/src/Xpressengine/User/Models/User.php
+++ b/core/src/Xpressengine/User/Models/User.php
@@ -40,22 +40,41 @@ class User extends DynamicModel implements
     CanResetPasswordContract,
     AuthorizableContract
 {
-    use Notifiable, Authenticatable, Authorizable;
+    use Authenticatable;
+    use Authorizable;
+    use Notifiable;
 
-    protected $table = 'user';
-
+    /**
+     * @var bool
+     */
     public $incrementing = false;
+
+    /**
+     * @var string
+     */
+    protected $table = 'user';
 
     /**
      * @var bool use dynamic query
      */
     protected $dynamic = true;
 
+    /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * @var string[]
+     */
     protected $dates = [
         'password_updated_at',
         'login_at'
     ];
 
+    /**
+     * @var string[]
+     */
     protected $fillable = [
         'email',
         'login_id',
@@ -73,14 +92,21 @@ class User extends DynamicModel implements
      *
      * @var array
      */
-    protected $visible = ['id', 'display_name', 'introduction', 'profileImage'];
+    protected $visible = [
+        'id',
+        'display_name',
+        'introduction',
+        'profileImage'
+    ];
 
     /**
      * The accessors to append to the model's array form.
      *
      * @var array
      */
-    protected $appends = ['profileImage'];
+    protected $appends = [
+        'profileImage'
+    ];
 
     /**
      * @var \Closure 회원의 프로필 이미지 Resolver.
@@ -98,10 +124,10 @@ class User extends DynamicModel implements
      */
     public static $displayField = 'display_name';
 
-    const STATUS_ACTIVATED = 'activated';
-    const STATUS_DENIED = 'denied';
-    const STATUS_PENDING_ADMIN = 'pending_admin';
-    const STATUS_PENDING_EMAIL = 'pending_email';
+    public const STATUS_ACTIVATED = 'activated';
+    public const STATUS_DENIED = 'denied';
+    public const STATUS_PENDING_ADMIN = 'pending_admin';
+    public const STATUS_PENDING_EMAIL = 'pending_email';
 
     /**
      * @var array
@@ -116,7 +142,7 @@ class User extends DynamicModel implements
     /**
      * User constructor.
      *
-     * @param array $attributes attributes
+     * @param  array  $attributes  attributes
      */
     public function __construct(array $attributes = [])
     {
@@ -129,7 +155,7 @@ class User extends DynamicModel implements
     /**
      * setProfileImageResolver
      *
-     * @param Closure $callback 회원의 프로필 이미지를 처리하기 위한 resolver
+     * @param  Closure  $callback  회원의 프로필 이미지를 처리하기 위한 resolver
      *
      * @return void
      */
@@ -155,12 +181,16 @@ class User extends DynamicModel implements
      */
     public function groups()
     {
-        $site_key = $this->site_key == null ? \XeSite::getCurrentSiteKey() : $this->site_key;
-        return $this->belongsToMany(UserGroup::class, 'user_group_user', 'user_id', 'group_id')->where('site_key',$site_key)->orderBy('order');
+        $site_key = $this->site_key ?? \XeSite::getCurrentSiteKey();
+
+        return $this->belongsToMany(UserGroup::class, 'user_group_user', 'user_id', 'group_id')->where(
+            'site_key',
+            $site_key
+        );
     }
 
     /**
-     * set relationship with us er accounts
+     * set relationship with user accounts
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
@@ -207,13 +237,13 @@ class User extends DynamicModel implements
     public function getEmailForPasswordReset()
     {
         // 만약 로그인시 사용된 이메일이 따로 지정돼 있을 경우 그 이메일을 사용한다.
-        return isset($this->emailForPasswordReset) ? $this->emailForPasswordReset : $this->email;
+        return $this->emailForPasswordReset ?? $this->email;
     }
 
     /**
      * Send the password reset notification.
      *
-     * @param  string $token token for password reset
+     * @param  string  $token  token for password reset
      * @return void
      */
     public function sendPasswordResetNotification($token)
@@ -224,7 +254,7 @@ class User extends DynamicModel implements
     /**
      * setEmailForPasswordReset() 메소드에서 반환할 email 정보를 지정한다.
      *
-     * @param string $email 지정할 email주소
+     * @param  string  $email  지정할 email주소
      *
      * @return void
      */
@@ -272,7 +302,7 @@ class User extends DynamicModel implements
     /**
      * Finds whether user has super rating.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAdmin()
     {
@@ -282,7 +312,7 @@ class User extends DynamicModel implements
     /**
      * Finds whether user has manager or super rating.
      *
-     * @return boolean
+     * @return bool
      */
     public function isManager()
     {
@@ -333,7 +363,7 @@ class User extends DynamicModel implements
     /**
      * 회원이 소유한 계정 중에 주어진 provider를 가진 계정을 반환한다.
      *
-     * @param  string  $provider provider
+     * @param  string  $provider  provider
      *
      * @return UserAccount
      */
@@ -351,7 +381,7 @@ class User extends DynamicModel implements
     /**
      * add this user to groups
      *
-     * @param mixed $groups groups
+     * @param  mixed  $groups  groups
      *
      * @return static
      */
@@ -365,7 +395,7 @@ class User extends DynamicModel implements
     /**
      * leave groups
      *
-     * @param array $groups groups
+     * @param  array  $groups  groups
      *
      * @return static
      */
@@ -379,7 +409,7 @@ class User extends DynamicModel implements
     /**
      * 최종 로그인 시간을 기록한다.
      *
-     * @param mixed $time 로그인 시간
+     * @param  mixed  $time  로그인 시간
      *
      * @return void
      */
@@ -394,7 +424,7 @@ class User extends DynamicModel implements
     /**
      * loginAt 처리, loginAt이 지정되지 않았을 경우, null을 반환하도록 처리한다.
      *
-     * @param string $value date time string
+     * @param  string  $value  date time string
      *
      * @return \Carbon\Carbon|null
      */

--- a/core/src/Xpressengine/User/Models/UserAccount.php
+++ b/core/src/Xpressengine/User/Models/UserAccount.php
@@ -27,11 +27,19 @@ use Xpressengine\User\AccountInterface;
  */
 class UserAccount extends DynamicModel implements AccountInterface
 {
-
-    protected $table = 'user_account';
-
+    /**
+     * @var bool
+     */
     public $incrementing = false;
 
+    /**
+     * @var string
+     */
+    protected $table = 'user_account';
+
+    /**
+     * @var string[]
+     */
     protected $fillable = [
         'user_id',
         'email',
@@ -46,6 +54,13 @@ class UserAccount extends DynamicModel implements AccountInterface
      * @var bool use dynamic query
      */
     protected $dynamic = false;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
 
     /**
      * set relationship with user

--- a/core/src/Xpressengine/User/Models/UserEmail.php
+++ b/core/src/Xpressengine/User/Models/UserEmail.php
@@ -28,10 +28,19 @@ use Xpressengine\User\Exceptions\AlreadyConfirmedEmailException;
  */
 class UserEmail extends DynamicModel implements EmailInterface
 {
+    /**
+     * @var string
+     */
     protected $table = 'user_email';
 
+    /**
+     * @var bool
+     */
     protected $dynamic = false;
 
+    /**
+     * @var string[]
+     */
     protected $fillable = [
         'user_id',
         'address'
@@ -50,7 +59,7 @@ class UserEmail extends DynamicModel implements EmailInterface
     /**
      * 이메일 주소를 반환한다.
      *
-     * @param bool $onlyEmailId true일 경우, 이메일의 `@`와 도메인을 제외한 앞부분만 반환한다.
+     * @param  bool  $onlyEmailId  true일 경우, 이메일의 `@`와 도메인을 제외한 앞부분만 반환한다.
      *
      * @return mixed
      */

--- a/core/src/Xpressengine/User/Models/UserTermAgree.php
+++ b/core/src/Xpressengine/User/Models/UserTermAgree.php
@@ -29,33 +29,47 @@ class UserTermAgree extends DynamicModel
 {
     use SoftDeletes;
 
+    /**
+     * @var bool
+     */
     public $incrementing = false;
 
+    /**
+     * @var string
+     */
     protected $table = 'user_term_agrees';
 
-    protected $fillable = ['user_id', 'term_id', 'site_key'];
+    /**
+     * The "type" of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
 
-    public static function boot()
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'user_id',
+        'term_id',
+        'site_key'
+    ];
+
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        $currentSiteKeyResolver = static function ($model) {
+            if (isset($model->site_key) === false) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
-        });
+        };
 
-        self::updating(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
-        self::saving(function($model){
-            if(!isset($model->site_key)){
-                $model->site_key = \XeSite::getCurrentSiteKey();
-            }
-        });
-
+        static::creating($currentSiteKeyResolver);
+        static::updating($currentSiteKeyResolver);
+        static::saving($currentSiteKeyResolver);
     }
 }

--- a/core/src/Xpressengine/Widget/Models/WidgetBox.php
+++ b/core/src/Xpressengine/Widget/Models/WidgetBox.php
@@ -30,14 +30,14 @@ class WidgetBox extends DynamicModel
     use WidgetBoxDataTrait;
 
     /**
-     * @var string table name
-     */
-    protected $table = 'widgetbox';
-
-    /**
      * @var bool
      */
     public $incrementing = false;
+
+    /**
+     * @var string table name
+     */
+    protected $table = 'widgetbox';
 
     /**
      * @var array
@@ -56,11 +56,16 @@ class WidgetBox extends DynamicModel
     ];
 
     /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * get Support Container
      *
-     * @return boolean
+     * @return bool
      */
-    public function isSupportContainer(): bool
+    public function isSupportContainer()
     {
         return Arr::get($this->getOptions(), 'supportContainer', $this->getPresenter()::SUPPORT_CONTAINER);
     }
@@ -70,17 +75,23 @@ class WidgetBox extends DynamicModel
      *
      * @return string
      */
-    public function getPresenter(): string
+    public function getPresenter()
     {
         return Arr::get($this->getAttributeValue('options'), 'presenter');
     }
 
-    public function getOptions(): array
+    /**
+     * @return array
+     */
+    public function getOptions()
     {
         return $this->getAttributeValue('options');
     }
 
-    public function getContent(): array
+    /**
+     * @return array
+     */
+    public function getContent()
     {
         $content = $this->getAttributeValue('content');
 
@@ -92,10 +103,10 @@ class WidgetBox extends DynamicModel
     /**
      * get containers content
      *
-     * @param array $containers
+     * @param  array  $containers
      * @return array
      */
-    private function getContainersContent(array $containers): array
+    private function getContainersContent(array $containers)
     {
         foreach ($containers as &$container) {
             $hasNotStringKeys = count(array_filter(array_keys($container), 'is_string')) === 0;
@@ -116,10 +127,10 @@ class WidgetBox extends DynamicModel
     /**
      * make rows content
      *
-     * @param array $rows
+     * @param  array  $rows
      * @return array
      */
-    private function getRowsContent(array $rows): array
+    private function getRowsContent(array $rows)
     {
         $rows = $this->getContainersToRaws($rows);
 
@@ -140,7 +151,7 @@ class WidgetBox extends DynamicModel
      * @param $data
      * @return array
      */
-    private function getContainerData($data): array
+    private function getContainerData($data)
     {
         return [
             'rows' => $data,
@@ -154,7 +165,7 @@ class WidgetBox extends DynamicModel
      * @param $data
      * @return array
      */
-    private function getRowData($data): array
+    private function getRowData($data)
     {
         return [
             'cols' => $data,
@@ -162,41 +173,50 @@ class WidgetBox extends DynamicModel
         ];
     }
 
-    public static function boot()
+    /**
+     * @return void
+     */
+    protected static function boot()
     {
         parent::boot();
 
-        self::creating(function($model){
-            if(!isset($model->site_key)){
+        self::creating(static function ($model) {
+            if (!isset($model->site_key)) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
         });
 
-        self::updating(function(WidgetBox $model){
+        self::updating(static function (WidgetBox $model) {
             $original = $model->getOriginal();
-            $originSupportContainer = json_decode($original['options'], JSON_OBJECT_AS_ARRAY)['presenter']::SUPPORT_CONTAINER;
+            $originSupportContainer = json_decode(
+                $original['options'],
+                JSON_OBJECT_AS_ARRAY
+            )['presenter']::SUPPORT_CONTAINER;
             $supportContainer = $model->getPresenter()::SUPPORT_CONTAINER;
 
             if ($supportContainer !== $originSupportContainer && $model->getAttributeValue('content')) {
-                if ($supportContainer) {
-                    $model->setAttribute('content', array($model->getAttributeValue('content')));
+                if ($supportContainer !== null) {
+                    $model->setAttribute('content', [$model->getAttributeValue('content')]);
                 }
             }
 
-            if (!isset($model->site_key)){
+            if (!isset($model->site_key)) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
 
-            $model->setAttribute('options', array_merge($model->getOptions(), [
-                'supportContainer' => $supportContainer
-            ]));
+            $model->setAttribute(
+                'options',
+                array_merge($model->getOptions(), [
+                    'supportContainer' => $supportContainer
+                ])
+            );
 
             $content = $model->getContent();
             $model->setAttribute('content', $content);
         });
 
-        self::saving(function($model){
-            if(!isset($model->site_key)){
+        self::saving(static function ($model) {
+            if (!isset($model->site_key)) {
                 $model->site_key = \XeSite::getCurrentSiteKey();
             }
         });
@@ -204,12 +224,16 @@ class WidgetBox extends DynamicModel
         static::observe(WidgetBoxHistoryObserver::class);
     }
 
-    private function getContainersToRaws(array $content): array
+    /**
+     * @param  array  $content
+     * @return array
+     */
+    private function getContainersToRaws(array $content)
     {
         $rows = [];
 
         foreach ($content as $container) {
-            if (array_key_exists('rows', $container) && count($container) > 0) {
+            if (array_key_exists('rows', $container) && empty($container) === false) {
                 array_push($rows, ...$container['rows']);
             }
         }

--- a/core/src/Xpressengine/Widget/Models/WidgetBoxHistory.php
+++ b/core/src/Xpressengine/Widget/Models/WidgetBoxHistory.php
@@ -15,25 +15,33 @@ class WidgetBoxHistory extends DynamicModel
     /**
      * Table
      */
-    const TABLE = 'widgetbox_history';
+    public const TABLE = 'widgetbox_history';
 
     /**
      * Columns
      */
-    const ID = 'id';
-    const WIDGETBOX_ID = 'widgetbox_id';
-    const SITE_KEY = 'site_key';
-    const CONTENT = 'content';
-    const OPTIONS = 'options';
-    const UPDATED_AT = null;
+    public const ID = 'id';
+    public const WIDGETBOX_ID = 'widgetbox_id';
+    public const SITE_KEY = 'site_key';
+    public const CONTENT = 'content';
+    public const OPTIONS = 'options';
+    public const UPDATED_AT = null;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     public $incrementing = true;
 
-    /** @var bool */
-    public $timestamps = ["created_at"];
+    /**
+     * @var string[]
+     */
+    public $timestamps = [
+        'created_at'
+    ];
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $table = self::TABLE;
 
     /** @var string */
@@ -49,32 +57,51 @@ class WidgetBoxHistory extends DynamicModel
         self::OPTIONS
     ];
 
-    /** @var string[] */
+    /**
+     * @var string[]
+     */
     protected $casts = [
         self::CONTENT => 'array',
         self::OPTIONS => 'array'
     ];
 
+    /**
+     * @return array|\ArrayAccess|mixed
+     */
     public function getPresenter()
     {
         return Arr::get($this->getAttributeValue('options'), 'presenter');
     }
 
+    /**
+     * @return array|\ArrayAccess|mixed
+     */
     public function isSupportContainer()
     {
         return Arr::get($this->getOptions(), 'supportContainer', false);
     }
 
+    /**
+     * @return mixed
+     */
     public function getWidgetBoxId()
     {
         return $this->getAttribute(self::WIDGETBOX_ID);
     }
 
+    /**
+     * @return mixed
+     */
     public function getOptions()
     {
         return $this->getAttributeValue(self::OPTIONS);
     }
 
+    /**
+     * @param $query
+     * @param  \Xpressengine\Widget\Models\WidgetBox  $widgetBox
+     * @return mixed
+     */
     public function scopeWhereWidgetbox($query, WidgetBox $widgetBox)
     {
         return $query->where([


### PR DESCRIPTION
라라벨 버전 6.x 부터 모델의 기본키가 정수가 아닌 경우에는 모델에 상속된 $keyType 프로퍼에 ‘string’ 값을 입력해줘야 합니다.
$keyType 프로퍼티가 올바르지 못하는 경우, 관계 사용 시 잘못된 결과물을 반환해줄 수 있습니다.