### PR TITLE
#1501 유저 모델에서 유저 약관 동의 relation이 존재하지 않는 이슈

### DIFF
--- a/core/src/Xpressengine/User/Models/Guest.php
+++ b/core/src/Xpressengine/User/Models/Guest.php
@@ -15,6 +15,7 @@
 namespace Xpressengine\User\Models;
 
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Xpressengine\User\Exceptions\UnsupportedOperationForGuestOrUnknownException;
 use Xpressengine\User\Rating;
@@ -231,10 +232,10 @@ class Guest implements UserInterface, AuthorizableContract
     /**
      * Get Terms a user agreed
      *
-     * @return array
+     * @return Collection
      */
     public function getAgreedTerms()
     {
-        return [];
+        return new Collection();
     }
 }

--- a/core/src/Xpressengine/User/Models/Guest.php
+++ b/core/src/Xpressengine/User/Models/Guest.php
@@ -227,4 +227,14 @@ class Guest implements UserInterface, AuthorizableContract
     {
         return null;
     }
+
+    /**
+     * Get Terms a user agreed
+     *
+     * @return array
+     */
+    public function getAgreedTerms()
+    {
+        return [];
+    }
 }

--- a/core/src/Xpressengine/User/Models/UnknownUser.php
+++ b/core/src/Xpressengine/User/Models/UnknownUser.php
@@ -212,4 +212,14 @@ class UnknownUser implements UserInterface
     {
         throw new UnsupportedOperationForGuestOrUnknownException();
     }
+
+    /**
+     * Get Terms a user agreed
+     *
+     * @return array
+     */
+    public function getAgreedTerms()
+    {
+        return [];
+    }
 }

--- a/core/src/Xpressengine/User/Models/UnknownUser.php
+++ b/core/src/Xpressengine/User/Models/UnknownUser.php
@@ -12,6 +12,7 @@
 
 namespace Xpressengine\User\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Xpressengine\User\Exceptions\UnsupportedOperationForGuestOrUnknownException;
 use Xpressengine\User\Rating;
 use Xpressengine\User\UserInterface;
@@ -216,10 +217,10 @@ class UnknownUser implements UserInterface
     /**
      * Get Terms a user agreed
      *
-     * @return array
+     * @return Collection
      */
     public function getAgreedTerms()
     {
-        return [];
+        return new Collection();
     }
 }

--- a/core/src/Xpressengine/User/Models/User.php
+++ b/core/src/Xpressengine/User/Models/User.php
@@ -16,10 +16,11 @@ namespace Xpressengine\User\Models;
 
 use Closure;
 use Illuminate\Auth\Authenticatable;
-use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
-use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
-use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Foundation\Auth\Access\Authorizable;
 use Xpressengine\User\Contracts\CanResetPassword as CanResetPasswordContract;
 use Xpressengine\User\Notifications\ResetPassword as ResetPasswordNotification;
 use Xpressengine\Database\Eloquent\DynamicModel;
@@ -481,11 +482,11 @@ class User extends DynamicModel implements
 
     /**
      * Get Terms a user agreed
-     * 
-     * @return array|mixed
+     *
+     * @return Collection
      */
     public function getAgreedTerms()
     {
-        return $this->getAttribute('agreedTerms') ?: [];
+        return $this->getAttribute('agreedTerms');
     }
 }

--- a/core/src/Xpressengine/User/Models/User.php
+++ b/core/src/Xpressengine/User/Models/User.php
@@ -220,6 +220,20 @@ class User extends DynamicModel implements
     }
 
     /**
+     * set relationship with user term agrees
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function agreedTerms()
+    {
+        $site_key = $this->site_key ?? \XeSite::getCurrentSiteKey();
+        return $this->belongsToMany(Term::class, 'user_term_agrees', 'user_id', 'term_id')->where(
+            'user_terms.site_key',
+            $site_key
+        )->whereNull('user_term_agrees.deleted_at');
+    }
+
+    /**
      * Get profile_image
      *
      * @return string
@@ -453,5 +467,14 @@ class User extends DynamicModel implements
         }
 
         return $displayName;
+    }
+
+    /**
+     * Get Terms a user agreed
+     * @return array|mixed
+     */
+    public function getAgreedTerms()
+    {
+        return $this->getAttribute('agreedTerms') ?: [];
     }
 }

--- a/core/src/Xpressengine/User/Models/User.php
+++ b/core/src/Xpressengine/User/Models/User.php
@@ -224,6 +224,16 @@ class User extends DynamicModel implements
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
+    public function allSiteAgreedTerms()
+    {
+        return $this->belongsToMany(Term::class, 'user_term_agrees', 'user_id', 'term_id');
+    }
+
+    /**
+     * set relationship with user term agrees
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
     public function agreedTerms()
     {
         $site_key = $this->site_key ?? \XeSite::getCurrentSiteKey();
@@ -471,6 +481,7 @@ class User extends DynamicModel implements
 
     /**
      * Get Terms a user agreed
+     * 
      * @return array|mixed
      */
     public function getAgreedTerms()

--- a/core/src/Xpressengine/User/UserInterface.php
+++ b/core/src/Xpressengine/User/UserInterface.php
@@ -115,4 +115,11 @@ interface UserInterface
      * @return static
      */
     public function leaveGroups(array $groups);
+
+    /**
+     * Get Terms a user agreed
+     *
+     * @return array
+     */
+    public function getAgreedTerms();
 }

--- a/core/src/Xpressengine/User/UserInterface.php
+++ b/core/src/Xpressengine/User/UserInterface.php
@@ -14,6 +14,8 @@
 
 namespace Xpressengine\User;
 
+use Illuminate\Database\Eloquent\Collection;
+
 /**
  * 회원 정보를 저장하는 클래스가 구현해야 하는 인터페이스
  *
@@ -119,7 +121,7 @@ interface UserInterface
     /**
      * Get Terms a user agreed
      *
-     * @return array
+     * @return Collection
      */
     public function getAgreedTerms();
 }


### PR DESCRIPTION
## 문제 재현 방법
유저 조회시 유저와 연관된 약관 동의 여부를 조회하거나, 수정하기 위해, relation을 사용할 수 없었습니다.

## 문제의 원인
유저 모델에 `UserTermAgree` 모델과 연관된 relation이 존재하지 않았습니다.

## 패치 내역
- `User` 모델에 `agreedTerms` 관계를 추가했습니다.
- `UserInterface` 인터페이스에 `getAgreedTerms` 메소드를 추가하고, `User`,`Guest`, `UnKnownUser`에 각각 구현부를 추가했습니다.
