### PR TITLE
[#1505] 회원가입 기본 스킨에 비밀번호 확인 필드 추가 및 가입 설정 관리자 페이지에 비밀번호 확인 필드 설정

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -215,6 +215,7 @@ class RegisterController extends Controller
         expose_trans('xe::passwordIncludeNumber');
         expose_trans('xe::passwordIncludeCharacter');
         expose_trans('xe::passwordIncludeSpecialCharacter');
+        expose_trans('xe::enterPasswordConfirmation');
 
         return \XePresenter::make('register.create', compact('config', 'parts'));
     }

--- a/assets/core/settings/js/register.js
+++ b/assets/core/settings/js/register.js
@@ -83,6 +83,12 @@ $(function () {
     $wrapDisplayname.trigger('toggle')
   })
   // end:display_name
+
+  var $wrapPasswordConfirm = $('.__regsetting-passwordconfirm-wrap');
+
+  $wrapPasswordConfirm.find('[name=use_password_confirm]').on('change', function () {
+    $('[name=require_password_confirm]').prop('checked', $(this).prop('checked'))
+  })
 })
 
 $.widget('xe.userRegisterDynamicFiled', {

--- a/core/src/Xpressengine/User/UserRegisterHandler.php
+++ b/core/src/Xpressengine/User/UserRegisterHandler.php
@@ -53,6 +53,7 @@ class UserRegisterHandler
         $attribute['display_name_unique'] = isset($attribute['display_name_unique']);
         $attribute['use_display_name'] = isset($attribute['use_display_name']);
         $attribute['use_login_id'] = isset($attribute['use_login_id']);
+        $attribute['use_password_confirm'] = isset($attribute['use_password_confirm']);
 
         $attribute['forms'] = array_keys(array_get($attribute, 'forms', []));
         $attribute['dynamic_fields'] = array_keys(array_get($attribute, 'dynamic_fields', []));

--- a/resources/views/settings/register.blade.php
+++ b/resources/views/settings/register.blade.php
@@ -318,6 +318,25 @@ use Xpressengine\User\UserRegisterHandler;
                                                 </label>
                                             </td>
                                         </tr>
+                                        {{-- password_confirm --}}
+                                        <tr class="__regsetting-passwordconfirm-wrap">
+                                            <td>
+                                                {{ xe_trans('xe::passwordConfirm') }}
+                                            </td>
+                                            <td class="text-align--center">
+                                                <label class="xu-label-checkradio">
+                                                    <input name="use_password_confirm" type="checkbox" @if ($config->get('use_password_confirm') === true) checked @endif>
+                                                    <span class="xu-label-checkradio__helper"></span>
+                                                </label>
+                                            </td>
+                                            <td class="text-align--center">
+                                                <label class="xu-label-checkradio xu-label-checkradio--disabled">
+                                                    <input name="require_password_confirm" type="checkbox" @if ($config->get('use_password_confirm') === true) checked @endif>
+                                                    <span class="xu-label-checkradio__helper"></span>
+                                                </label>
+                                            </td>
+                                        </tr>
+
                                     </tbody>
                                 </table>
                             </div>

--- a/resources/views/user/skins/default/auth/register/forms/new_default.blade.php
+++ b/resources/views/user/skins/default/auth/register/forms/new_default.blade.php
@@ -41,6 +41,19 @@
     </div>
 </div>
 
+{{-- password confirmation --}}
+@if (app('xe.config')->getVal('user.register.use_password_confirm') === true)
+    <div class="xu-form-group xu-form-group--large">
+        <label class="xu-form-group__label" for="f-password-confirm">{{ xe_trans('xe::passwordConfirm') }}</label>
+        <div class="xu-form-group__box xu-form-group__box--icon-right">
+            <input type="password" id="f-password-confirm-confirm" class="xu-form-group__control" placeholder="{{ xe_trans('xe::enterPassword') }}" name="password_confirmation" required data-valid-name="{{xe_trans('xe::password')}}">
+            <button type="button" class="xu-form-group__icon __xe-toggle-password">
+                <i class="xi-eye"></i>
+            </button>
+        </div>
+    </div>
+@endif
+
 <script>
     $(function () {
         $('.__xe-toggle-password').on('click', function () {


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
현재는 비밀번호 확인 항목에 대한 설정이나, ui가 관리자 페이지, 회원가입 기본 스킨에서 노출되지 않고있습니다.

## 문제의 원인
이전 커밋에서 관련 ui가 삭제된 것으로 보입니다.

## 패치 내역
*어떤걸 수정했나요?*
비밀번호 확인 설정 필드를 관리자 페이지에 추가해주고, 사용 설정 시, 회원가입 기본 스킨에서 노출되록 수정해주었습니다.

<img width="1907" alt="image" src="https://github.com/xpressengine/xpressengine/assets/63186553/21b8f261-c346-4515-967e-514e7da23074">

<img width="823" alt="image" src="https://github.com/xpressengine/xpressengine/assets/63186553/c0de94a1-9f1b-4e9d-b80e-b82d237bde7e">
