### PR TITLE
#1507 회원가입 시 display_name validation 문구가 제대로 노출되지 않는 이슈

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -563,6 +563,7 @@ class RegisterController extends Controller
         $valid = true;
         $message = 'xe::usableDisplayName';
         $displayName = trim($request->get('display_name'));
+        $displayNameCaption = xe_trans(app('xe.config')->getVal('user.register.display_name_caption'));
 
         try {
             $this->handler->validateDisplayName($displayName);
@@ -574,7 +575,12 @@ class RegisterController extends Controller
         }
 
         return XePresenter::makeApi(
-            ['type' => 'success', 'message' => xe_trans($message), 'displayName' => $displayName, 'valid' => $valid]
+            [
+                'type' => 'success',
+                'message' => xe_trans($message, ['displayName' => $displayNameCaption]),
+                'displayName' => $displayName,
+                'valid' => $valid
+            ]
         );
     }
 


### PR DESCRIPTION
Pull request는 반드시 develop 브랜치로 보내주시기 바랍니다.

## 문제 재현 방법
회원 가입시에, 닉네임 input에 적절한 닉네임을 입력하면 validation 문구가 노출되는데, 이때 validation 문구에 `:displayName` 이라는 파라미터가 채워지지 않은 상태로 노출되고 있습니다.

## 문제의 원인
관련 로직이 존재하지 않았습니다.

## 패치 내역
validation 문구 노출 시, displayNameCation라는 translation 문구를 가져와서 파라미터에 넣도록 수정했습니다.
