### PR TITLE
#1511 플러그인 상에서 커맨드를 실행하는 scedule을 생성해주고, 크론으로 schedule 실행시 커맨드가 두번 실행되는 이슈

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -134,7 +134,9 @@ class Kernel extends ConsoleKernel
                             if(array_get($this->scheduledPlugins, $config->site_key) == null) {
                                 $this->scheduledPlugins[$config->site_key] = [];
                             }
-                            $this->scheduledPlugins[$config->site_key][] = $pluginObj;
+                            if (!in_array($pluginObj, $this->scheduledPlugins[$config->site_key])) {
+                                $this->scheduledPlugins[$config->site_key][] = $pluginObj;
+                            }
                         }
 
                         //register command class of plugin

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -116,6 +116,11 @@ class Kernel extends ConsoleKernel
             $configs = \DB::table('config')->where('name', 'plugin')->get();
             foreach ($configs as $config) {
                 $vars = json_dec($config->vars, true);
+
+                if (blank(array_get($this->scheduledPlugins, $config->site_key))) {
+                    $this->scheduledPlugins[$siteKey] = [];
+                }
+
                 foreach ($vars['list'] as $id => $val) {
                     if ($val['status'] == 'activated') {
                         $entity = \XePlugin::getPlugin($id);
@@ -131,12 +136,7 @@ class Kernel extends ConsoleKernel
                         //register schedule method of plugin
                         //커맨드라인에서 URL없이 접속하기때문에, 사이트키 구분을 위해 해당 플러그인이 활성화된 사이트의 config에 붙어있는 site_key를 활용
                         if (method_exists($pluginObj, 'schedule')) {
-                            if(array_get($this->scheduledPlugins, $config->site_key) == null) {
-                                $this->scheduledPlugins[$config->site_key] = [];
-                            }
-                            if (!in_array($pluginObj, $this->scheduledPlugins[$config->site_key])) {
-                                $this->scheduledPlugins[$config->site_key][] = $pluginObj;
-                            }
+                            $this->scheduledPlugins[$config->site_key][$pluginObj->getId()] = $pluginObj;
                         }
 
                         //register command class of plugin


### PR DESCRIPTION
## 문제 재현 방법
plugin 상에서 `schedule` 을 등록시켜준 후, crontab 을 통해 실행시켜줄때, 두번씩 실행되는 이슈가 있습니다.

## 문제의 원인
커널(`app/Console/Kernel.php`)상에서 `scheduledPlugins` 에 플러그인 적재 시, 플러그인이 두번씩 적재되는 이슈가 있었습니다.

## 패치 내역
`scheduledPlugins`에 플러그인을 넣을때, 이미 적재가 되었다면, 적재가 되지 않도록 조건문을 추가했습니다.
